### PR TITLE
finished v1 of the address parser feature

### DIFF
--- a/parserator_web/static/css/custom.css
+++ b/parserator_web/static/css/custom.css
@@ -1,1 +1,5 @@
 /* Add custom style overrides here. */
+.error {
+  padding-top: 20px;
+  color: darkred;
+}

--- a/parserator_web/templates/parserator_web/index.html
+++ b/parserator_web/templates/parserator_web/index.html
@@ -9,26 +9,25 @@
     <div class="col-12">
       <h3 id="usaddress-parser"><i class="fa fa-fw fa-map-marker-alt"></i> U.S. address parser</h3>
       <p>Dealing with some messy or unstructured addresses? We can parse them for you.</p>
-      <div class="card card-body bg-light">
+      <div class="card card-body bg-light" id="parser">
         <p><strong>Try it out!</strong> Parse an address in the United States into fields like <code>AddressNumber</code>, <code>StreetName</code> and <code>ZipCode</code>.</p>
-        <form class="form" role="form">
+        <form class="form" role="form" id="address-form">
           {% csrf_token %}
           <input name="address" type="text" class="form-control" id="address" placeholder="123 Main St. Suite 100 Chicago, IL">
           <button id="submit" type="submit" class="btn btn-success mt-3">Parse!</button>
         </form>
       </div>
-      <!-- TODO: Display parsed address components here. -->
       <div id="address-results" style="display:none">
         <h4>Parsing results</h4>
         <p>Address type: <strong><span id="parse-type"></span></strong></p>
-        <table class="table table-bordered">
+        <table class="table table-bordered" id="table">
           <thead>
             <tr>
               <th>Address part</th>
               <th>Tag</th>
             </tr>
           </thead>
-          <tbody>
+          <tbody id="table-body">
           </tbody>
         </table>
       </div>
@@ -39,7 +38,81 @@
 
 {% block extra_js %}
   <script type="text/javascript">
-    /* TODO: Flesh this out to connect the form to the API and render results
-    in the #address-results div. */
+  (function() {
+    async function getAndRenderAddressComponentsTable(input) {
+      const urlWithParams = `${window.location.href}api/parse/?address=${encodeURIComponent(input)}`;
+
+      const request = new XMLHttpRequest();
+      request.open('GET', urlWithParams, true);
+      request.send();
+
+      request.onload = function() {
+        if (request.status === 200) {
+          const response = JSON.parse(request.response)
+          renderAddressComponentTable(response)
+        } else {
+          const error = JSON.parse(request.response)
+          renderError(error.detail)
+        }
+      }
+
+      request.onerror = function() {
+        renderError()
+      }
+    }
+
+    function renderAddressComponentTable(results) {
+      const div = document.getElementById('address-results');
+      div.style = "display: block;";
+      
+      // add the address type to the display
+      const addressType = document.getElementById('parse-type');
+      addressType.innerHTML = results.address_type ? results.address_type : 'No address type.';
+
+      // render table with the address components
+      const table = document.getElementById('table').getElementsByTagName('tbody')[0];
+
+      for (const [key, value] of Object.entries(results.address_components)) {
+        let row = table.insertRow(table.rows.length);
+
+        let keyCell = row.insertCell(0);
+        let keyText = document.createTextNode(key);
+        keyCell.appendChild(keyText);
+
+        let valueCell = row.insertCell(1);
+        let valueText = document.createTextNode(value);
+        valueCell.appendChild(valueText);
+      }
+    }
+
+    function renderError(error = 'Oh no! Something bad happened.') {
+      const div = document.getElementById('parser');
+      const p = document.createElement('p');
+
+      p.className = 'error';
+      p.innerHTML = error;
+      div.appendChild(p);
+
+      setTimeout(() => p.remove(), 3000);
+    }
+
+    function resetTable() {
+      let oldTableBody = document.getElementById('table-body');
+      let newTableBody = document.createElement('tbody');
+      newTableBody.id = oldTableBody.id
+      oldTableBody.parentNode.replaceChild(newTableBody, oldTableBody)
+    }
+
+    const form = document.getElementById('address-form');
+
+    form.addEventListener('submit', async function(event) {
+      event.preventDefault();
+      
+      resetTable()
+
+      const addressInput = event.target.elements.address.value;
+      getAndRenderAddressComponentsTable(addressInput);
+    });
+  })();
   </script>
 {% endblock %}

--- a/parserator_web/templates/parserator_web/index.html
+++ b/parserator_web/templates/parserator_web/index.html
@@ -107,7 +107,7 @@
 
     form.addEventListener('submit', async function(event) {
       event.preventDefault();
-      
+
       resetTable()
 
       const addressInput = event.target.elements.address.value;

--- a/parserator_web/views.py
+++ b/parserator_web/views.py
@@ -14,11 +14,25 @@ class AddressParse(APIView):
     renderer_classes = [JSONRenderer]
 
     def get(self, request):
-        # TODO: Flesh out this method to parse an address string using the
-        # parse() method and return the parsed components to the frontend.
-        return Response({})
+        address = request.query_params.get('address')
+
+        if not address:
+            raise ParseError('Query did not contain an address.')
+        else:
+            parsed_address = self.parse(address)
+            return Response(parsed_address)
+
 
     def parse(self, address):
-        # TODO: Implement this method to return the parsed components of a
-        # given address using usaddress: https://github.com/datamade/usaddress
-        return address_components, address_type
+        try:
+            parsed_address_results = usaddress.tag(address)
+
+            parsed_address = {
+                'input_string': address,
+                'address_components': parsed_address_results[0],
+                'address_type': parsed_address_results[1]
+            }
+
+            return parsed_address
+        except usaddress.RepeatedLabelError:
+            raise ParseError(f"Unable to process address: {address}")

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,15 +1,31 @@
 import pytest
+import urllib
 
 
-def test_api_parse_succeds(client):
-    # TODO: Finish this test. Send a request to the API and confirm that the
-    # data comes back in the appropriate format.
+def test_api_parse_succeeds(client):
     address_string = '123 main st chicago il'
-    pytest.fail()
+    url = encode_address_for_query_string(address_string)
+    response = client.get(url)
+    
+    assert response.status_code == 200
+    assert response.data.get('input_string') == address_string
+    assert response.data.get('address_type') == 'Street Address'
+    assert isinstance(response.data.get('address_components'), dict)
 
 
 def test_api_parse_raises_error(client):
-    # TODO: Finish this test. The address_string below will raise a
-    # RepeatedLabelError, so ParseAddress.parse() will not be able to parse it.
     address_string = '123 main st chicago il 123 main st'
-    pytest.fail()
+    url = encode_address_for_query_string(address_string)
+    response = client.get(url)
+    assert response.status_code == 400
+
+    empty_string = ''
+    url = encode_address_for_query_string(empty_string)
+    response = client.get(url)
+    assert response.status_code == 400
+
+
+def encode_address_for_query_string(address_string):
+    query_string = urllib.parse.urlencode({'address': address_string})
+    url = f'/api/parse/?{query_string}'
+    return url


### PR DESCRIPTION
## Overview
This PR is for Sam McAlilly's code challenge submission. The code has an API endpoint which parses address strings and returns the component parts of the address string. The feature includes a UI with a submission form where users can request the address components for specific addresses.

### Demo
Follow the installation directions outlined [in the repo's readme](https://github.com/smcalilly/code-challenge#installation).

You can visit the app at http://localhost:8000. 

## Testing Instructions
#### Manual Testing
- Test the search form with an address string: `123 main st chicago il`. This is the happy path.
- Test the search form with an address string: `123 main st chicago il 123 main st`. This should return an error.
- Test the API endpoint without the UI like this: `http://localhost:8000/api/parse/?address=123%20main%20st%20chicago%20il`. That is the happy path.

#### Automated Testing
In a terminal session in the repo's root directory, run:
```
docker-compose -f docker-compose.yml -f tests/docker-compose.yml run --rm app
```
